### PR TITLE
Allow no-email customers.

### DIFF
--- a/pages/overall/insert/insert_rating.php
+++ b/pages/overall/insert/insert_rating.php
@@ -15,6 +15,8 @@ $sessionCode = isset($_SESSION['SessionCode']) ? $_SESSION['SessionCode'] : '';
 require_once 'classes/TaskLoader.php';
 require_once 'classes/BrevadaAPI.php';
 require_once 'classes/APITasks/Task.Feedback.class.php';
+
+TaskFeedback::insertSessionData($sessionCode, false, time());
 TaskFeedback::insertRating($rating, $aspectID, $sessionCode);
 
 exit('OK');


### PR DESCRIPTION
This was actually working at one point. I think some commit broke it. I narrowed down the exact cause (not creating session_data unless you submit your email or some field). The commit contained in this PR will always create a session_data row.

I'll have to retroactively create session_data rows for past sessions. This will introduce many "customers" to some users. They'll have to just hit acknowledge.

The MySQL which I'll run on the production server (tested on dev):

```
INSERT IGNORE INTO session_data (SessionCode, Acknowledged, SubmissionTime)
SELECT feedback.SessionCode as 'SessionCode', 0 as 'Acknowledged', UNIX_TIMESTAMP(MIN(feedback.Date)) as 'SubmissionTime'
FROM feedback
LEFT JOIN session_data ON session_data.SessionCode = feedback.SessionCode
WHERE
    feedback.SessionCode IS NOT NULL AND feedback.SessionCode <> '' AND
    session_data.SessionCode IS NULL
GROUP BY feedback.SessionCode
```
