### PR TITLE
Multi-Option Aspect Type

### DIFF
--- a/app/core/data/Data.php
+++ b/app/core/data/Data.php
@@ -40,6 +40,9 @@ class Data
     /** @var integer The "to" unix time for which this Data collection represents. */
     protected $to = null;
 
+    /** @var boolean Is the data type numeric in nature? */
+    protected $isNumeric = true;
+
     /**
      * Instantiate a Data instance from an array of responses.
      *
@@ -50,12 +53,9 @@ class Data
     {
         $this->responses = $responses;
 
-        if (isset($opts['from'])) {
-            $this->from = $opts['from'];
-        }
-        if (isset($opts['to'])) {
-            $this->to = $opts['to'];
-        }
+        if (isset($opts['from'])) $this->from = $opts['from'];
+        if (isset($opts['to'])) $this->to = $opts['to'];
+        if (isset($opts['numeric'])) $this->isNumeric = (bool) $opts['numeric'];
     }
 
     /**
@@ -71,10 +71,13 @@ class Data
     /**
      * Gets the sum of all values.
      *
+     * @throws \Exception if data type is not numeric.
      * @return double
      */
     public function getSum()
     {
+        if (!$this->isNumeric) throw new \Exception('Data type is not numeric.');
+
         return array_reduce($this->responses, function ($carry, $item) {
             return $carry + $item->getValue();
         }, 0);
@@ -93,13 +96,14 @@ class Data
     /**
      * Gets the average of all values.
      *
+     * @throws \Exception if data type is not numeric.
      * @return double
      */
     public function getAverage()
     {
-        if ($this->isEmpty()) {
-            return null;
-        }
+        if (!$this->isNumeric) throw new \Exception('Data type is not numeric.');
+
+        if ($this->isEmpty()) return null;
         return $this->getSum() / $this->getCount();
     }
 
@@ -306,11 +310,14 @@ class Data
      * Returns the difference between the averages of two datasets if both
      * averages are defined, otherwise returns null.
      *
+     * @throws \Exception if data type is not numeric.
      * @param self $other
      * @return integer|double
      */
     public function getAverageDiff($other)
     {
+        if (!$this->isNumeric) throw new \Exception('Data type is not numeric.');
+
         $a = $this->getAverage();
         $b = $other->getAverage();
 

--- a/app/core/data/IResponse.php
+++ b/app/core/data/IResponse.php
@@ -14,9 +14,9 @@ namespace Brv\core\data;
 interface IResponse
 {
     /**
-     * Gets the response rating value.
+     * Gets the response value.
      *
-     * @return double
+     * @return double|object
      */
     public function getValue();
 

--- a/app/impl/controllers/Aspect.php
+++ b/app/impl/controllers/Aspect.php
@@ -284,7 +284,8 @@ class Aspect extends Controller
             'title' => $aspect->getTitle(),
             'description' => $aspect->getDescription(),
             'active' => $aspect->isActive() == 1,
-            'custom' => $aspect->isCustom() == 1
+            'custom' => $aspect->isCustom() == 1,
+            'value_types' => $aspect->getValueTypes()
         ];
 
         if ($dataSpan !== false) {

--- a/app/impl/entities/Aspect.php
+++ b/app/impl/entities/Aspect.php
@@ -22,7 +22,8 @@ use Brv\core\data\Data;
 class Aspect extends Entity
 {
     use common\StoreId,
-        common\Active;
+        common\Active,
+        common\ValueTypes;
 
     /**
      * Instantiates an aspect entity from a data row.
@@ -48,7 +49,8 @@ class Aspect extends Entity
             $stmt = DB::get()->prepare("
                 SELECT
                     aspects.*, aspect_type.Title,
-                    NOT(ISNULL(aspect_type.CompanyID)) as custom
+                    NOT(ISNULL(aspect_type.CompanyID)) as custom,
+                    aspect_type.ValueTypes
                 FROM aspects
                 JOIN aspect_type ON aspect_type.id = aspects.AspectTypeID
                 WHERE aspects.id = :id
@@ -81,7 +83,8 @@ class Aspect extends Entity
             $stmt = DB::get()->prepare("
                 SELECT
                     aspects.*, aspect_type.Title,
-                    NOT(ISNULL(aspect_type.CompanyID)) as custom
+                    NOT(ISNULL(aspect_type.CompanyID)) as custom,
+                    aspect_type.ValueTypes
                 FROM aspects
                 JOIN aspect_type ON aspect_type.id = aspects.AspectTypeID
                 WHERE aspects.id IN ({$idsList})
@@ -113,7 +116,8 @@ class Aspect extends Entity
             $stmt = DB::get()->prepare("
                 SELECT
                     aspects.*, aspect_type.Title,
-                    NOT(ISNULL(aspect_type.CompanyID)) as custom
+                    NOT(ISNULL(aspect_type.CompanyID)) as custom,
+                    aspect_type.ValueTypes
                 FROM aspects
                 JOIN aspect_type ON aspect_type.id = aspects.AspectTypeID
                 WHERE aspects.AspectTypeID = :type_id AND aspects.StoreID = :store_id
@@ -145,7 +149,8 @@ class Aspect extends Entity
             $stmt = DB::get()->prepare("
                 SELECT
                     aspects.*, aspect_type.Title,
-                    NOT(ISNULL(aspect_type.CompanyID)) as custom
+                    NOT(ISNULL(aspect_type.CompanyID)) as custom,
+                    aspect_type.ValueTypes
                 FROM aspects
                 JOIN aspect_type ON aspect_type.id = aspects.AspectTypeID
                 WHERE aspects.StoreID = :id

--- a/app/impl/entities/AspectType.php
+++ b/app/impl/entities/AspectType.php
@@ -16,6 +16,8 @@ use Brv\core\libs\database\Database as DB;
  */
 class AspectType extends Entity
 {
+    use common\ValueTypes;
+
     /**
      * Instantiates an aspect type entity from a data row.
      *
@@ -69,9 +71,13 @@ class AspectType extends Entity
         }
 
         try {
-            $stmt = DB::get()->prepare("INSERT INTO aspect_type SET Title = :title, CompanyID = :companyId");
+            $stmt = DB::get()->prepare("
+                INSERT INTO aspect_type
+                SET Title = :title, CompanyID = :companyId, ValueTypes = :valueTypes
+            ");
             $stmt->bindValue(':title', $this->getTitle(), \PDO::PARAM_STR);
             $stmt->bindValue(':companyId', $this->get('CompanyID'), \PDO::PARAM_INT);
+            $stmt->bindValue(':valueTypes', $this->get('ValueTypes'), \PDO::PARAM_STR);
             $stmt->execute();
             $this->set('id', (int) DB::get()->lastInsertId());
             return $this->getId();
@@ -100,5 +106,37 @@ class AspectType extends Entity
     public function isCustom()
     {
         return ((int) $this->get('custom')) === 1;
+    }
+
+    /**
+     * Adds a value type to the aspect type.
+     *
+     * @param string $key   The value key.
+     * @param string $value The value label.
+     */
+    public function addValueType($key, $value)
+    {
+        $values = $this->getValueTypes();
+        if ($values === null) $values = [];
+
+        $values[$key] = $value;
+        $this->set('ValueTypes', json_encode($values, true));
+    }
+
+    /**
+     * Removes a value type from the aspect type.
+     *
+     * @param string $key   The value key.
+     */
+    public function removeValueType($key)
+    {
+        $values = $this->getValueTypes();
+        if ($values === null) $values = [];
+        if (isset($values[$key])) unset($values[$key]);
+        if (empty($values)) {
+            $this->set('ValueTypes', null);
+        } else {
+            $this->set('ValueTypes', json_encode($values, true));
+        }
     }
 }

--- a/app/impl/entities/common/ValueTypes.php
+++ b/app/impl/entities/common/ValueTypes.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * ValueTypes | Common Entity Trait
+ *
+ * @version v0.0.1 (July. 03, 2017)
+ * @copyright Copyright (c) 2017, Brevada
+ */
+
+namespace Brv\impl\entities\common;
+
+trait ValueTypes {
+    /**
+     * Returns the possible value types of the aspect type. Returns null
+     * if traditional rating system is used.
+     *
+     * @return array Assoc. array where key is internal value type key, and value
+     * is the human readable label.
+     */
+    public function getValueTypes()
+    {
+        $raw = $this->get('ValueTypes');
+        if (empty($raw)) return null;
+
+        return json_decode($raw);
+    }
+}

--- a/app/res/css/src/feedback/_aspects.scss
+++ b/app/res/css/src/feedback/_aspects.scss
@@ -13,8 +13,9 @@
         width: 100%;
         margin: 10px 0;
         opacity: 1;
-        max-height: 150px;
+        max-height: 220px;
         @include user-select(none);
+        @extend %clearfix;
 
         .header {
             font-size: 1.1em;

--- a/app/res/css/src/feedback/_aspects.scss
+++ b/app/res/css/src/feedback/_aspects.scss
@@ -49,55 +49,8 @@
     }
 }
 
-.aspect .rating-bar {
-
-    .ratings {
-        @include flexbox;
-        @include flex-direction(row);
-        // TODO: space-* not supported in older browsers.
-        @include justify-content(space-between);
-
-        .rating {
-            width: 19.5%;
-            height: 68px;
-            display: inline-block;
-            background-image: url(inline-image("feedback/star.png"));
-            background-repeat: no-repeat;
-            background-position: center center;
-
-            @extend %clickable;
-
-            @include rating(background-color);
-            &.rating-0 { background-size: 10%; }
-            &.rating-1 { background-size: 15%; }
-            &.rating-2 { background-size: 20%; }
-            &.rating-3 { background-size: 25%; }
-            &.rating-4 { background-size: 30%; }
-
-            &:active {
-                @include opacity(0.5);
-            }
-
-            @at-root body:not(.touch-device) #{&}:hover {
-                @include opacity(0.5);
-            }
-
-            &:active {
-                @include box-shadow(inset 0 0 6px 1px $grey5);
-            }
-        }
-    }
-
-    .hint {
-        display: inline-block;
-        width: 100%;
-        color: $grey3;
-        font-size: 0.925em;
-        margin-top: 3px;
-
-        @extend %clearfix;
-    }
-}
+@import 'aspectinput/rating';
+@import 'aspectinput/multioption';
 
 .aspect .submitted {
     text-align: center;

--- a/app/res/css/src/feedback/aspectinput/_multioption.scss
+++ b/app/res/css/src/feedback/aspectinput/_multioption.scss
@@ -1,23 +1,34 @@
 .aspect .multi-option-bar {
+    margin-bottom: 0.3em;
 
     .options {
         @include flexbox;
         @include flex-direction(row);
         // TODO: space-* not supported in older browsers.
         @include justify-content(space-around);
+        @include flex-wrap(wrap);
 
         .value-type {
             @include flexbox;
             @include flex-direction(column);
             @include justify-content(center);
             @include align-content(center);
+            @include flex-grow(1);
 
             min-height: 68px;
             background: $grey3;
             color: #fff;
-            padding: 0.25em 1.5em;
-            margin: 0.1em 0.15em;
+            padding: 0.25em 1.75em;
             font-size: 1.22em;
+            text-align: center;
+
+            margin: 0.1em 0.25em;
+            &:first-child {
+                margin-left: 0;
+            }
+            &:last-child {
+                margin-right: 0;
+            }
 
             @extend %clickable;
 

--- a/app/res/css/src/feedback/aspectinput/_multioption.scss
+++ b/app/res/css/src/feedback/aspectinput/_multioption.scss
@@ -1,0 +1,37 @@
+.aspect .multi-option-bar {
+
+    .options {
+        @include flexbox;
+        @include flex-direction(row);
+        // TODO: space-* not supported in older browsers.
+        @include justify-content(space-around);
+
+        .value-type {
+            @include flexbox;
+            @include flex-direction(column);
+            @include justify-content(center);
+            @include align-content(center);
+
+            min-height: 68px;
+            background: $grey3;
+            color: #fff;
+            padding: 0.25em 1.5em;
+            margin: 0.1em 0.15em;
+            font-size: 1.22em;
+
+            @extend %clickable;
+
+            &:active {
+                @include opacity(0.5);
+            }
+
+            @at-root body:not(.touch-device) #{&}:hover {
+                @include opacity(0.5);
+            }
+
+            &:active {
+                @include box-shadow(inset 0 0 6px 1px $grey5);
+            }
+        }
+    }
+}

--- a/app/res/css/src/feedback/aspectinput/_multioption.scss
+++ b/app/res/css/src/feedback/aspectinput/_multioption.scss
@@ -4,31 +4,25 @@
     .options {
         @include flexbox;
         @include flex-direction(row);
-        // TODO: space-* not supported in older browsers.
-        @include justify-content(space-around);
         @include flex-wrap(wrap);
+        @include justify-content(flex-start);
+
+        margin: 0 -0.4em;
 
         .value-type {
             @include flexbox;
             @include flex-direction(column);
             @include justify-content(center);
             @include align-content(center);
-            @include flex-grow(1);
 
-            min-height: 68px;
+            min-height: 50px;
             background: $grey3;
             color: #fff;
-            padding: 0.25em 1.75em;
-            font-size: 1.22em;
+            padding: 0.25em 2em;
+            font-size: 1.1em;
             text-align: center;
 
-            margin: 0.1em 0.25em;
-            &:first-child {
-                margin-left: 0;
-            }
-            &:last-child {
-                margin-right: 0;
-            }
+            margin: 0.1em 0.4em 0.4em 0.4em;
 
             @extend %clickable;
 
@@ -43,6 +37,10 @@
             &:active {
                 @include box-shadow(inset 0 0 6px 1px $grey5);
             }
+        }
+
+        &.binary .value-type, &.unary .value-type {
+            @include flex-grow(1);
         }
     }
 }

--- a/app/res/css/src/feedback/aspectinput/_rating.scss
+++ b/app/res/css/src/feedback/aspectinput/_rating.scss
@@ -1,0 +1,49 @@
+.aspect .rating-bar {
+
+    .ratings {
+        @include flexbox;
+        @include flex-direction(row);
+        // TODO: space-* not supported in older browsers.
+        @include justify-content(space-between);
+
+        .rating {
+            width: 19.5%;
+            height: 68px;
+            display: inline-block;
+            background-image: url(inline-image("feedback/star.png"));
+            background-repeat: no-repeat;
+            background-position: center center;
+
+            @extend %clickable;
+
+            @include rating(background-color);
+            &.rating-0 { background-size: 10%; }
+            &.rating-1 { background-size: 15%; }
+            &.rating-2 { background-size: 20%; }
+            &.rating-3 { background-size: 25%; }
+            &.rating-4 { background-size: 30%; }
+
+            &:active {
+                @include opacity(0.5);
+            }
+
+            @at-root body:not(.touch-device) #{&}:hover {
+                @include opacity(0.5);
+            }
+
+            &:active {
+                @include box-shadow(inset 0 0 6px 1px $grey5);
+            }
+        }
+    }
+
+    .hint {
+        display: inline-block;
+        width: 100%;
+        color: $grey3;
+        font-size: 0.925em;
+        margin-top: 3px;
+
+        @extend %clearfix;
+    }
+}

--- a/app/res/js/src/dashboard/aspects/Aspect.js
+++ b/app/res/js/src/dashboard/aspects/Aspect.js
@@ -86,6 +86,17 @@ const AspectBody = props => {
         return (<BlankState />);
     }
 
+    if (props.nonStandard) {
+        return (
+            <div className="body">
+                <div className="blank-state">
+                    <i className={"fa fa-question-circle"}></i>
+                    <span>{"Unsupported Aspect Type"}</span>
+                </div>
+            </div>
+        );
+    }
+
     return (
         <div className="body">
             <Badges
@@ -108,7 +119,12 @@ const AspectBody = props => {
 
 AspectBody.propTypes = {
     summary: PropTypes.object.isRequired,
-    filter: PropTypes.string.isRequired
+    filter: PropTypes.string.isRequired,
+    nonStandard: PropTypes.bool
+};
+
+AspectBody.defaultProps = {
+    nonStandard: false
 };
 
 /**
@@ -121,11 +137,13 @@ export default class Aspect extends Component {
         id: PropTypes.number.isRequired,
         summary: PropTypes.object.isRequired,
         filter: PropTypes.string.isRequired,
-        onRemove: PropTypes.func
+        onRemove: PropTypes.func,
+        nonStandard: PropTypes.bool
     };
 
     static defaultProps = {
-        onRemove: () => { /* no op */ }
+        onRemove: () => { /* no op */ },
+        nonStandard: false
     };
 
     /**
@@ -221,6 +239,7 @@ export default class Aspect extends Component {
                         <AspectBody
                             filter={this.props.filter}
                             summary={this.props.summary}
+                            nonStandard={this.props.nonStandard}
                         />
                     ) }
                 </div>

--- a/app/res/js/src/dashboard/aspects/AspectContainer.js
+++ b/app/res/js/src/dashboard/aspects/AspectContainer.js
@@ -80,6 +80,7 @@ export default class AspectContainer extends Component {
                             id={aspect.id}
                             title={aspect.title}
                             summary={aspect.summary}
+                            nonStandard={aspect.value_types != null}
                             filter={this.props.filter}
                             onRemove={this.onRemove}
                         />

--- a/app/res/js/src/feedback/Aspects.js
+++ b/app/res/js/src/feedback/Aspects.js
@@ -43,9 +43,9 @@ export default class Aspects extends React.Component {
      * @param  {object} nextProps React props
      */
     componentWillReceiveProps(nextProps) {
-        if (!nextProps.aspects ||
-                _.isEqual(_.sortBy(nextProps.aspects, ["id"]),
-                          _.sortBy(this.state.aspects, ["id"])) ) {
+        if (!nextProps.aspects || _.isEqual(
+            _.sortBy(nextProps.aspects, ["id"]),
+            _.sortBy(this.state.aspects, ["id"]))) {
             return;
         }
 
@@ -73,10 +73,10 @@ export default class Aspects extends React.Component {
     render() {
         /* Don't show blacklisted aspects (removed list). */
         const aspects = this.state.aspects
-                                  .concat()
-                                  .filter(a => (
-                                      !this.state.submitted.includes(a.id)
-                                  ));
+            .concat()
+            .filter(a => (
+                !this.state.submitted.includes(a.id)
+            ));
 
         if (brv.feedback) {
             brv.feedback.session.setRemainingCount(aspects.length);
@@ -89,6 +89,7 @@ export default class Aspects extends React.Component {
                         key={aspect.id}
                         id={aspect.id}
                         title={aspect.title}
+                        valueTypes={aspect.value_types}
                         onSubmit={this.onSubmit}
                         session={this.props.session}
                     />

--- a/app/res/js/src/feedback/inputs/MultiOption.js
+++ b/app/res/js/src/feedback/inputs/MultiOption.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import classNames from "classnames";
 
 /**
  * Individual option within the multi option input.
@@ -42,7 +43,11 @@ Option.defaultProps = {
  */
 const MultiOption = props => (
     <div className="multi-option-bar">
-        <div className="options">
+        <div
+            className={classNames("options", {
+                binary: Object.keys(props.valueTypes).length === 2,
+                unary: Object.keys(props.valueTypes).length === 1
+            })}>
             {Object.keys(props.valueTypes).map((typeKey) => (
                 <Option
                     key={typeKey}

--- a/app/res/js/src/feedback/inputs/MultiOption.js
+++ b/app/res/js/src/feedback/inputs/MultiOption.js
@@ -1,0 +1,67 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+/**
+ * Individual option within the multi option input.
+ * @param   {object} props React props
+ * @param   {number} props.value Value type key.
+ * @param   {string} props.label Human readable label of the value type option.
+ * @param   {function({value_type})} props.onClick Handles submission of rating.
+ * @returns {JSX}
+ */
+const Option = props => {
+    const onClick = () => ( // eslint-disable-line require-jsdoc
+        props.onClick({ value_type: props.value })
+    );
+
+    return (
+        <div
+            className="value-type"
+            onClick={onClick}>
+            {props.label}
+        </div>
+    );
+};
+
+Option.propTypes = {
+    value: PropTypes.string.isRequired,
+    onClick: PropTypes.func,
+    label: PropTypes.string.isRequired
+};
+
+Option.defaultProps = {
+    onClick: () => { /* no op */ }
+};
+
+/**
+ * MultiOption input.
+ * @param   {object} props React props
+ * @param   {object} props.valueTypes Key-value pairs of value type keys: labels.
+ * @param   {function({value_type})} props.onClick Handles submission of rating.
+ * @returns {JSX}
+ */
+const MultiOption = props => (
+    <div className="multi-option-bar">
+        <div className="options">
+            {Object.keys(props.valueTypes).map((typeKey) => (
+                <Option
+                    key={typeKey}
+                    label={props.valueTypes[typeKey]}
+                    value={typeKey}
+                    onClick={props.onSubmit}
+                />
+            ))}
+        </div>
+    </div>
+);
+
+MultiOption.propTypes = {
+    onSubmit: PropTypes.func,
+    valueTypes: PropTypes.object.isRequired
+};
+
+MultiOption.defaultProps = {
+    onSubmit: () => { /* no op */ }
+};
+
+export { Option, MultiOption as default };

--- a/app/res/js/src/feedback/inputs/Rating.js
+++ b/app/res/js/src/feedback/inputs/Rating.js
@@ -6,12 +6,12 @@ import PropTypes from "prop-types";
  * @param   {object} props React props
  * @param   {number} props.ordinal The rating's ordinal value, rather than percent.
  * @param   {number} props.value Rating's percent value.
- * @param   {function(number, number)} props.onClick Handles submission of rating.
+ * @param   {function({value, ordinal})} props.onClick Handles submission of rating.
  * @returns {JSX}
  */
 const Rating = props => {
     const onClick = () => ( // eslint-disable-line require-jsdoc
-        props.onClick(props.value, props.ordinal)
+        props.onClick({ value: props.value, ordinal: props.ordinal })
     );
 
     return (
@@ -35,7 +35,7 @@ Rating.defaultProps = {
 /**
  * 5 star rating bar.
  * @param   {object} props React props
- * @param   {function(number, number)} props.onClick Handles submission of rating.
+ * @param   {function({value, ordinal})} props.onClick Handles submission of rating.
  * @returns {JSX}
  */
 const RatingBar = props => (

--- a/app/res/js/src/global/feedback/session.js
+++ b/app/res/js/src/global/feedback/session.js
@@ -16,8 +16,9 @@ module.exports = function() {
      * @returns {void}
      */
     const newToken = () => {
-        _token = require("crypto").randomBytes(16)
-                                  .toString("hex");
+        _token = require("crypto")
+            .randomBytes(16)
+            .toString("hex");
 
         return _token;
     };
@@ -39,8 +40,8 @@ module.exports = function() {
     session.getToken = () => _token;
     session.hasPoor = () => _hasPoor;
 
-    session.onSubmit = (value, ordinal) => {
-        if (ordinal <= 1) {
+    session.onSubmit = ({ ordinal }) => {
+        if (ordinal != null && ordinal <= 1) {
             _hasPoor = true;
         }
     };

--- a/specs/schema/schema.sql
+++ b/specs/schema/schema.sql
@@ -203,6 +203,7 @@ CREATE TABLE IF NOT EXISTS `aspect_type` (
   `Title` VARCHAR(50) NULL DEFAULT '',
   `Description` VARCHAR(200) NULL,
   `CompanyID` INT(11) NULL,
+  `ValueTypes` TEXT NULL, /* stored as JSON */
   PRIMARY KEY (`id`),
    FOREIGN KEY (`CompanyID`) REFERENCES companies(`id`)
      ON DELETE SET NULL


### PR DESCRIPTION
## Summary

- Added a new type of non-standard input, the multi-option input.
- Added "unsupported aspect type" placeholder to dashboard, in place of properly displaying the non-standard data.
- Added (currently unused) "numeric" option to Data, to prevent use of numeric functions (avg, sum) on non-numeric data types (e.g. multi-option).
- Increased _aspects.scss max-height to 220px to allow for multiple multi-options past 1 row.

## Schema Changes

```mysql
ALTER TABLE `aspect_type` ADD COLUMN `ValueTypes` TEXT NULL;
```

## Limitations

- Data collected via multi-option is not displayed in the dashboard.
- Multi-option (or non-standard) responses are not inherently associated with IP Address and User Agent.
- The max-height in _aspects.scss poses a currently _unenforced_ limitation on the number of options allowed, mainly by cutting off options exceeding the allowable height.